### PR TITLE
Specify orientation for document camera controller

### DIFF
--- a/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
+++ b/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
@@ -58,7 +58,6 @@ import AcuantCommon
         c.autoCapture = cameraOptions.autoCapture
         c.hideNavBar = cameraOptions.hideNavigationBar
         c.captureIntervalInSeconds = Double(cameraOptions.timeInMsPerDigit)/Double(1000)
-        c.supportedOrientations = supportedOrientations
         return c
     }
     

--- a/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
+++ b/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
@@ -48,8 +48,9 @@ import AcuantCommon
     private var currentStateCount = 0
     private var nextState = FrameResult.NO_DOCUMENT
     private var isNavigationHidden = false
+    private var supportedOrientations: UIInterfaceOrientationMask = .portrait
     
-    public class func getCameraController(delegate:CameraCaptureDelegate, cameraOptions: AcuantCameraOptions)->DocumentCameraController{
+    public class func getCameraController(delegate:CameraCaptureDelegate, cameraOptions: AcuantCameraOptions, supportedOrientations: UIInterfaceOrientationMask = UIInterfaceOrientationMask.all)->DocumentCameraController{
         let c = DocumentCameraController()
         c.cameraCaptureDelegate = delegate
         c.options = cameraOptions
@@ -57,7 +58,12 @@ import AcuantCommon
         c.autoCapture = cameraOptions.autoCapture
         c.hideNavBar = cameraOptions.hideNavigationBar
         c.captureIntervalInSeconds = Double(cameraOptions.timeInMsPerDigit)/Double(1000)
+        c.supportedOrientations = supportedOrientations
         return c
+    }
+    
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return self.supportedOrientations
     }
 
     override public func viewDidLoad() {

--- a/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
+++ b/AcuantCamera/AcuantCamera/Camera/Document/DocumentCameraController.swift
@@ -48,9 +48,9 @@ import AcuantCommon
     private var currentStateCount = 0
     private var nextState = FrameResult.NO_DOCUMENT
     private var isNavigationHidden = false
-    private var supportedOrientations: UIInterfaceOrientationMask = .portrait
+    private var supportedOrientations: UIInterfaceOrientationMask?
     
-    public class func getCameraController(delegate:CameraCaptureDelegate, cameraOptions: AcuantCameraOptions, supportedOrientations: UIInterfaceOrientationMask = UIInterfaceOrientationMask.all)->DocumentCameraController{
+    public class func getCameraController(delegate:CameraCaptureDelegate, cameraOptions: AcuantCameraOptions, supportedOrientations: UIInterfaceOrientationMask?=nil)->DocumentCameraController{
         let c = DocumentCameraController()
         c.cameraCaptureDelegate = delegate
         c.options = cameraOptions
@@ -58,11 +58,13 @@ import AcuantCommon
         c.autoCapture = cameraOptions.autoCapture
         c.hideNavBar = cameraOptions.hideNavigationBar
         c.captureIntervalInSeconds = Double(cameraOptions.timeInMsPerDigit)/Double(1000)
+        c.supportedOrientations = supportedOrientations
+        
         return c
     }
     
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return self.supportedOrientations
+        return self.supportedOrientations ?? super.supportedInterfaceOrientations
     }
 
     override public func viewDidLoad() {

--- a/AcuantiOSSDKV11.podspec
+++ b/AcuantiOSSDKV11.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     s.swift_versions = ['5.3']
     s.ios.deployment_target = '11.0'
     s.name         = "AcuantiOSSDKV11"
-    s.version      = "11.4.6"
+    s.version      = "11.4.6.1"
     s.summary      = "Acuant's latest SDK with most advanced image capture technology and optimized user workflow  "
     s.description  = "Acuant's latest SDK with most advanced image capture technology and optimized user workflow.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Acuant iOS SDK v11.4.6
+# Acuant iOS SDK v11.4.6.1
 
 **November 2020**
 
@@ -117,7 +117,7 @@ The SDK includes the following modules:
 1. If you are using COCOAPODS, then add the following podfile:
 
 		platform :ios, '11'
-		pod 'AcuantiOSSDKV11', '~> 11.4.6' #for all packages
+		pod 'AcuantiOSSDKV11', '~> 11.4.6.1' #for all packages
 		
 		#indepedent packages below
 		
@@ -354,7 +354,8 @@ Initialize without a Subscription ID:
 		
 ### Capture an Image using AcuantCamera
 
-1. AcuantCamera is best used in portrait mode. Lock the orientation of the app before using Camera. 
+1. AcuantCamera is best used in portrait mode. Lock the orientation of the app before using Camera. It is also possible to specify the orientation of the camera in the `DocumentCameraController` constructor
+by using a `UIInterfaceOrientationMask`.
 
 1. Set up callbacks:
 		


### PR DESCRIPTION
Allows us to specify the supported device orientation for the Document Camera Controller, done via dependency injection in the constructor.